### PR TITLE
Support multiple language prefixes for nijijourney.com

### DIFF
--- a/background.js
+++ b/background.js
@@ -4,7 +4,10 @@ chrome.runtime.onInstalled.addListener(() => {
       {
         conditions: [
           new chrome.declarativeContent.PageStateMatcher({
-            pageUrl: { urlMatches: 'www.midjourney.com/app/jobs/' },
+            pageUrl: {
+              urlMatches:
+                "(www.midjourney.com|nijijourney.com)/([a-z]{2}/)?app/jobs/",
+            },
           }),
         ],
         actions: [new chrome.declarativeContent.RequestContentScript({ js: ['content_script.js'] })],

--- a/content_script.js
+++ b/content_script.js
@@ -53,7 +53,7 @@ async function processPage() {
 }
 
 function isTargetURL(url) {
-  const pattern = /^https?:\/\/www\.midjourney\.com\/app\/jobs\//;
+  const pattern = /^https?:\/\/(www\.midjourney\.com|nijijourney\.com)\/([a-z]{2}\/)?app\/jobs\//;
   return pattern.test(url);
 }
 


### PR DESCRIPTION
This pull request updates the URL matching patterns in `content_script.js` and `background.js` to support multiple language prefixes for nijijourney.com, in addition to the existing support for www.midjourney.com.

With these changes, the extension will now work on URLs like:

- www.midjourney.com/app/jobs
- nijijourney.com/en/app/jobs
- nijijourney.com/zh/app/jobs
- nijijourney.com/ja/app/jobs
- nijijourney.com/ko/app/jobs

The updated regular expressions will match any two lowercase letters as a language prefix for nijijourney.com.
